### PR TITLE
Don't show welcome to previously identified users

### DIFF
--- a/Classes/Welcome/BranchWelcomeViewController.m
+++ b/Classes/Welcome/BranchWelcomeViewController.m
@@ -27,7 +27,7 @@ NSInteger const DEFAULT_REFERRAL_LINK_RETRY_COUNT = 3;
 @implementation BranchWelcomeViewController
 
 + (BOOL)shouldShowWelcome:(NSDictionary *)branchOpts {
-    return branchOpts[BRANCH_INVITE_USER_FULLNAME_KEY] != nil;
+    return branchOpts[BRANCH_INVITE_USER_FULLNAME_KEY] != nil && ![[Branch getInstance] isUserIdentified];
 }
 
 + (BranchWelcomeViewController *)branchWelcomeViewControllerWithDelegate:(id <BranchWelcomeControllerDelegate>)delegate branchOpts:(NSDictionary *)branchOpts {


### PR DESCRIPTION
@aaustin @qinweigong @francisjervis
Users who have already been identified by the developer don't need to be welcomed.