### PR TITLE
Undo 0.3.3

### DIFF
--- a/BranchInvite.podspec
+++ b/BranchInvite.podspec
@@ -29,5 +29,5 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
   }
 
   s.dependency 'Branch'
-  s.dependency 'HMSegmentedControl'
+  s.dependency 'HMSegmentedControl', '1.4' # Note, this is *required* because later versions don't support iOS 6.
 end

--- a/Classes/Invite/BranchInviteViewController.m
+++ b/Classes/Invite/BranchInviteViewController.m
@@ -91,8 +91,8 @@
     }
 
     // Set up all of the defaults
-    self.segmentedControl.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor whiteColor]};
-    self.segmentedControl.selectedTitleTextAttributes = @{NSForegroundColorAttributeName: [UIColor whiteColor]};
+    self.segmentedControl.textColor = [UIColor whiteColor];
+    self.segmentedControl.selectedTextColor = [UIColor whiteColor];
     self.segmentedControl.selectionIndicatorColor = [UIColor whiteColor];
     self.segmentedControl.backgroundColor = self.inviteItemColor;
     self.segmentedControl.selectionStyle = HMSegmentedControlSelectionStyleBox;

--- a/Classes/Referral/BranchReferralController.m
+++ b/Classes/Referral/BranchReferralController.m
@@ -144,8 +144,8 @@
     NSString *referrer = transaction[@"referrer"];
     NSString *referree = transaction[@"referree"];
     
-    BOOL referreeIsSetAndIsNotMe = referree && referree != (id)[NSNull null] && ![referree isEqualToString:currentSessionId];
-    BOOL referrerIsSetAndIsMe = referrer && referrer != (id)[NSNull null] && [referrer isEqualToString:currentSessionId];
+    BOOL referreeIsSetAndIsNotMe = referree && ![referree isEqualToString:currentSessionId];
+    BOOL referrerIsSetAndIsMe = referrer && [referrer isEqualToString:currentSessionId];
     
     // This transaction is a referral made by me if one of the two are true:
     // * The referree is set (BranchReferringUser type referrals), and  it is not me. If it is me, that means I was referred.

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Branch (0.10.0)
+  - Branch (0.10.1)
   - BranchInvite (0.3.3):
     - Branch
-    - HMSegmentedControl
-  - HMSegmentedControl (1.5.2)
+    - HMSegmentedControl (= 1.4)
+  - HMSegmentedControl (1.4.0)
 
 DEPENDENCIES:
   - BranchInvite (from `..`)
@@ -13,8 +13,8 @@ EXTERNAL SOURCES:
     :path: ..
 
 SPEC CHECKSUMS:
-  Branch: d31fe46ca1b969e6ab20e8e29d6541036a5f8cfb
-  BranchInvite: 694d6d9b291633166e21d4330dfbe9e57ee63c41
-  HMSegmentedControl: 83b9686022d2176fb6457d2bdb61e5d6393fed7d
+  Branch: 39c728c3b3b69c2f5c598bb923a7a68e8a9a4de2
+  BranchInvite: 49aa8170ea931ea703a0604c84a38fcb36d91342
+  HMSegmentedControl: c2fffcd5f391c1bcd3db510b1bea645fce4e08e5
 
-COCOAPODS: 0.37.1
+COCOAPODS: 0.37.2


### PR DESCRIPTION
@aaustin 

This reverts the changes for 0.3.3, which are no longer necessary with the 0.10.1 tag of the Branch-iOS-SDK.
Additionally, it pins 1.4 of HMSegementedControl again, which is required until/unless we stop supporting iOS 6.