### PR TITLE
check in iphone specific xibs

### DIFF
--- a/Resources/BranchInviteDefaultContactCell~iphone.xib
+++ b/Resources/BranchInviteDefaultContactCell~iphone.xib
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BranchInviteDefaultContactCell"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="ContactCell" id="Y72-x3-Xjd" customClass="BranchInviteDefaultContactCell">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Y72-x3-Xjd" id="J0K-Xa-8vm">
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Tlg-Pb-MGZ">
+                        <rect key="frame" x="8" y="8" width="40" height="40"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="40" id="G3l-vg-g3R"/>
+                            <constraint firstAttribute="width" constant="40" id="tKD-l1-bhx"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="66P-ph-jCG">
+                        <rect key="frame" x="56" y="18" width="42" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✔︎" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1xD-jS-YcC">
+                        <rect key="frame" x="291" y="18" width="21" height="21"/>
+                        <color key="backgroundColor" red="0.1764705882352941" green="0.61568627450980395" blue="0.73725490196078436" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="21" id="wdO-Zi-FXh"/>
+                            <constraint firstAttribute="height" constant="21" id="zZG-xP-SOk"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="66P-ph-jCG" firstAttribute="centerY" secondItem="Tlg-Pb-MGZ" secondAttribute="centerY" id="BVX-mQ-Hod"/>
+                    <constraint firstItem="66P-ph-jCG" firstAttribute="centerY" secondItem="1xD-jS-YcC" secondAttribute="centerY" id="RAr-xq-XPh"/>
+                    <constraint firstAttribute="trailing" secondItem="1xD-jS-YcC" secondAttribute="trailing" constant="8" id="hKD-yj-0g9"/>
+                    <constraint firstItem="Tlg-Pb-MGZ" firstAttribute="leading" secondItem="J0K-Xa-8vm" secondAttribute="leading" constant="8" id="nQU-xE-n2S"/>
+                    <constraint firstItem="Tlg-Pb-MGZ" firstAttribute="top" secondItem="J0K-Xa-8vm" secondAttribute="top" constant="8" id="q19-06-20P"/>
+                    <constraint firstItem="66P-ph-jCG" firstAttribute="leading" secondItem="Tlg-Pb-MGZ" secondAttribute="trailing" constant="8" id="qDD-wO-Phu"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="contactImageView" destination="Tlg-Pb-MGZ" id="Jsd-JG-zSU"/>
+                <outlet property="contactNameLabel" destination="66P-ph-jCG" id="qXP-8e-Zne"/>
+                <outlet property="selectionIcon" destination="1xD-jS-YcC" id="16O-9Y-I1d"/>
+            </connections>
+            <point key="canvasLocation" x="546" y="325"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Resources/BranchInviteViewController~iphone.xib
+++ b/Resources/BranchInviteViewController~iphone.xib
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BranchInviteViewController">
+            <connections>
+                <outlet property="contactTable" destination="PrD-g2-lRs" id="7oX-cj-2Gd"/>
+                <outlet property="searchBar" destination="3nZ-M1-ddd" id="8QX-Mp-vsb"/>
+                <outlet property="segmentedControl" destination="GGn-J9-uch" id="RZJ-2Y-3T0"/>
+                <outlet property="segmentedControlHeightConstraint" destination="Thy-zn-lX8" id="xNY-2N-GiR"/>
+                <outlet property="view" destination="Wah-5Z-Gdf" id="VLH-Uk-WJl"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="Wah-5Z-Gdf">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GGn-J9-uch" customClass="HMSegmentedControl">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="60"/>
+                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="60" id="Thy-zn-lX8"/>
+                    </constraints>
+                </view>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="PrD-g2-lRs">
+                    <rect key="frame" x="0.0" y="104" width="600" height="496"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="VdE-XI-mAs"/>
+                        <outlet property="delegate" destination="-1" id="rx7-Ux-Kov"/>
+                    </connections>
+                </tableView>
+                <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="3nZ-M1-ddd">
+                    <rect key="frame" x="0.0" y="60" width="600" height="44"/>
+                    <textInputTraits key="textInputTraits"/>
+                    <connections>
+                        <outlet property="delegate" destination="-1" id="cCA-rS-BAZ"/>
+                    </connections>
+                </searchBar>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="3nZ-M1-ddd" secondAttribute="trailing" id="5wS-Zk-343"/>
+                <constraint firstItem="GGn-J9-uch" firstAttribute="leading" secondItem="Wah-5Z-Gdf" secondAttribute="leading" id="LVQ-O4-Ljq"/>
+                <constraint firstItem="PrD-g2-lRs" firstAttribute="top" secondItem="3nZ-M1-ddd" secondAttribute="bottom" id="Nnf-p9-6dd"/>
+                <constraint firstItem="3nZ-M1-ddd" firstAttribute="top" secondItem="GGn-J9-uch" secondAttribute="bottom" id="Qb9-g6-nhk"/>
+                <constraint firstItem="PrD-g2-lRs" firstAttribute="leading" secondItem="Wah-5Z-Gdf" secondAttribute="leading" id="Qqu-54-WWl"/>
+                <constraint firstItem="3nZ-M1-ddd" firstAttribute="leading" secondItem="Wah-5Z-Gdf" secondAttribute="leading" id="awd-R8-9dj"/>
+                <constraint firstAttribute="bottom" secondItem="PrD-g2-lRs" secondAttribute="bottom" id="bnv-zd-Svf"/>
+                <constraint firstAttribute="trailing" secondItem="GGn-J9-uch" secondAttribute="trailing" id="cND-00-zuT"/>
+                <constraint firstAttribute="trailing" secondItem="PrD-g2-lRs" secondAttribute="trailing" id="j7w-7m-oDI"/>
+                <constraint firstItem="GGn-J9-uch" firstAttribute="top" secondItem="Wah-5Z-Gdf" secondAttribute="top" id="s8g-L1-ESW"/>
+            </constraints>
+            <point key="canvasLocation" x="564" y="448"/>
+        </view>
+    </objects>
+</document>

--- a/Resources/BranchReferralDefaultView~iphone.xib
+++ b/Resources/BranchReferralDefaultView~iphone.xib
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7531" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="BranchReferralDefaultView">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qyu-wG-WW1">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="277"/>
+                    <subviews>
+                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UMf-TK-hLz">
+                            <rect key="frame" x="285" y="109" width="30" height="60"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="40"/>
+                            <state key="normal">
+                                <color key="titleColor" red="0.1764705882" green="0.61568627450000002" blue="0.73725490199999999" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                            </state>
+                            <connections>
+                                <action selector="showReferralsPressed:" destination="iN0-l3-epB" eventType="touchUpInside" id="IUD-AD-HZE"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="centerY" secondItem="UMf-TK-hLz" secondAttribute="centerY" id="FI2-vd-lMH"/>
+                        <constraint firstAttribute="centerX" secondItem="UMf-TK-hLz" secondAttribute="centerX" id="Q14-59-Dso"/>
+                    </constraints>
+                </view>
+                <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F7m-ao-2eM">
+                    <rect key="frame" x="0.0" y="277" width="600" height="0.0"/>
+                    <subviews>
+                        <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="dCO-52-fkn">
+                            <rect key="frame" x="0.0" y="0.0" width="600" height="0.0"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <outlet property="dataSource" destination="iN0-l3-epB" id="oam-nJ-uUF"/>
+                                <outlet property="delegate" destination="iN0-l3-epB" id="Fup-1b-T65"/>
+                            </connections>
+                        </tableView>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstItem="dCO-52-fkn" firstAttribute="leading" secondItem="F7m-ao-2eM" secondAttribute="leading" id="2gp-BT-3KV"/>
+                        <constraint firstItem="dCO-52-fkn" firstAttribute="top" secondItem="F7m-ao-2eM" secondAttribute="top" id="BQ3-mp-6FS"/>
+                        <constraint firstAttribute="bottom" secondItem="dCO-52-fkn" secondAttribute="bottom" id="IWY-jf-PBP"/>
+                        <constraint firstAttribute="trailing" secondItem="dCO-52-fkn" secondAttribute="trailing" id="LTu-14-ZpJ"/>
+                        <constraint firstAttribute="height" id="Q1Z-u0-zWj"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9BK-F7-KAB">
+                    <rect key="frame" x="0.0" y="277" width="600" height="277"/>
+                    <subviews>
+                        <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="288" translatesAutoresizingMaskIntoConstraints="NO" id="4AU-Rb-Bb2">
+                            <rect key="frame" x="300" y="139" width="0.0" height="0.0"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="40"/>
+                            <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mIU-15-nss" customClass="BranchReferralTriangleView">
+                            <rect key="frame" x="276" y="0.0" width="48" height="24"/>
+                            <color key="backgroundColor" red="0.1764705882" green="0.61568627450000002" blue="0.73725490199999999" alpha="1" colorSpace="calibratedRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="48" id="bvi-eo-2EI"/>
+                                <constraint firstAttribute="height" constant="24" id="l7g-ET-794"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" red="0.1764705882" green="0.61568627450000002" blue="0.73725490199999999" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="centerX" secondItem="mIU-15-nss" secondAttribute="centerX" id="2Bz-NT-bgm"/>
+                        <constraint firstAttribute="centerX" secondItem="4AU-Rb-Bb2" secondAttribute="centerX" id="6UF-c4-3gp"/>
+                        <constraint firstAttribute="centerY" secondItem="4AU-Rb-Bb2" secondAttribute="centerY" id="7mH-hu-I59"/>
+                        <constraint firstItem="mIU-15-nss" firstAttribute="top" secondItem="9BK-F7-KAB" secondAttribute="top" id="npA-dM-LX7"/>
+                    </constraints>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b7m-z0-xVS">
+                    <rect key="frame" x="239" y="562" width="121" height="30"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="30" id="S8X-HS-Ldc"/>
+                    </constraints>
+                    <state key="normal" title="Invite More Users">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="inviteUsersPressed:" destination="iN0-l3-epB" eventType="touchUpInside" id="vhp-xK-ujc"/>
+                    </connections>
+                </button>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="F7m-ao-2eM" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="4N7-DE-211"/>
+                <constraint firstItem="9BK-F7-KAB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="4Va-rp-CEh"/>
+                <constraint firstItem="qyu-wG-WW1" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="CsR-up-d1r"/>
+                <constraint firstAttribute="trailing" secondItem="qyu-wG-WW1" secondAttribute="trailing" id="FhU-Hm-Bzj"/>
+                <constraint firstAttribute="bottom" secondItem="b7m-z0-xVS" secondAttribute="bottom" constant="8" id="LpT-km-hXM"/>
+                <constraint firstAttribute="trailing" secondItem="F7m-ao-2eM" secondAttribute="trailing" id="QGP-qB-AX4"/>
+                <constraint firstItem="F7m-ao-2eM" firstAttribute="top" secondItem="qyu-wG-WW1" secondAttribute="bottom" id="WEB-0j-XaQ"/>
+                <constraint firstAttribute="centerX" secondItem="b7m-z0-xVS" secondAttribute="centerX" id="ZLI-50-s33"/>
+                <constraint firstItem="qyu-wG-WW1" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Zlq-eA-hKT"/>
+                <constraint firstItem="9BK-F7-KAB" firstAttribute="top" secondItem="F7m-ao-2eM" secondAttribute="bottom" id="fCB-9K-0fy"/>
+                <constraint firstItem="qyu-wG-WW1" firstAttribute="height" secondItem="9BK-F7-KAB" secondAttribute="height" id="fLm-4z-cvE"/>
+                <constraint firstAttribute="trailing" secondItem="9BK-F7-KAB" secondAttribute="trailing" id="uVq-cr-hPw"/>
+                <constraint firstItem="b7m-z0-xVS" firstAttribute="top" secondItem="9BK-F7-KAB" secondAttribute="bottom" constant="8" id="zar-mL-BZH"/>
+            </constraints>
+            <connections>
+                <outlet property="creditHistoryTransactionTable" destination="dCO-52-fkn" id="FuG-3G-evr"/>
+                <outlet property="creditsLabel" destination="4AU-Rb-Bb2" id="lMO-ue-Bv3"/>
+                <outlet property="inviteButton" destination="b7m-z0-xVS" id="vIE-6o-VIB"/>
+                <outlet property="inviteButtonBottomConstraint" destination="LpT-km-hXM" id="RhV-Zg-NBc"/>
+                <outlet property="inviteButtonHeightConstraint" destination="S8X-HS-Ldc" id="miN-pw-QTc"/>
+                <outlet property="pointsView" destination="9BK-F7-KAB" id="0H7-iD-p6F"/>
+                <outlet property="pointsViewBottomConstraint" destination="zar-mL-BZH" id="fQl-dX-fKQ"/>
+                <outlet property="referralCountLabel" destination="UMf-TK-hLz" id="T1S-O0-Gwt"/>
+                <outlet property="referralListHeightConstraint" destination="Q1Z-u0-zWj" id="8nR-sb-bnm"/>
+                <outlet property="transactionsView" destination="F7m-ao-2eM" id="baj-gF-fyd"/>
+            </connections>
+            <point key="canvasLocation" x="594" y="330"/>
+        </view>
+    </objects>
+</document>

--- a/Resources/BranchSharingDefaultView~iphone.xib
+++ b/Resources/BranchSharingDefaultView~iphone.xib
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7531" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="BranchSharingDefaultView">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="304" translatesAutoresizingMaskIntoConstraints="NO" id="zLN-K7-z63">
+                    <rect key="frame" x="148" y="328" width="304" height="18"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                    <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hi9-ty-7zy">
+                    <rect key="frame" x="140" y="0.0" width="320" height="320"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="320" id="B4u-AX-F3z"/>
+                        <constraint firstAttribute="width" constant="320" id="GCN-jA-jUp"/>
+                    </constraints>
+                </imageView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YQs-XT-rcD">
+                    <rect key="frame" x="274" y="354" width="53" height="30"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="30" id="QnZ-7h-HYv"/>
+                    </constraints>
+                    <inset key="contentEdgeInsets" minX="8" minY="0.0" maxX="8" maxY="0.0"/>
+                    <state key="normal" title="Done">
+                        <color key="titleColor" red="0.17647058823529413" green="0.61568627450980395" blue="0.73725490196078436" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                </button>
+            </subviews>
+            <color key="backgroundColor" red="0.17647058823529413" green="0.61568627450980395" blue="0.73725490196078436" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstAttribute="centerX" secondItem="YQs-XT-rcD" secondAttribute="centerX" id="59e-Tu-wu7"/>
+                <constraint firstItem="zLN-K7-z63" firstAttribute="top" secondItem="hi9-ty-7zy" secondAttribute="bottom" constant="8" id="LEK-pd-Rcl"/>
+                <constraint firstItem="zLN-K7-z63" firstAttribute="trailing" secondItem="hi9-ty-7zy" secondAttribute="trailing" constant="-8" id="Zz7-1p-Y9a"/>
+                <constraint firstItem="YQs-XT-rcD" firstAttribute="top" secondItem="zLN-K7-z63" secondAttribute="bottom" constant="8" id="aFz-je-qb7"/>
+                <constraint firstAttribute="centerX" secondItem="hi9-ty-7zy" secondAttribute="centerX" id="cwv-6r-0kM"/>
+                <constraint firstItem="zLN-K7-z63" firstAttribute="leading" secondItem="hi9-ty-7zy" secondAttribute="leading" constant="8" id="d9f-Hg-Yy3"/>
+                <constraint firstItem="hi9-ty-7zy" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="vcm-zK-MfL"/>
+            </constraints>
+            <connections>
+                <outlet property="contentImageView" destination="hi9-ty-7zy" id="vH7-v6-U8t"/>
+                <outlet property="contentTextLabel" destination="zLN-K7-z63" id="D8J-VG-goR"/>
+                <outlet property="doneButton" destination="YQs-XT-rcD" id="CGd-uL-c9a"/>
+            </connections>
+        </view>
+    </objects>
+</document>

--- a/Resources/BranchWelcomeDefaultView~iphone.xib
+++ b/Resources/BranchWelcomeDefaultView~iphone.xib
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="BranchWelcomeDefaultView">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rj8-Qz-eTI">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="172"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kv2-l0-R3n">
+                            <rect key="frame" x="16" y="20" width="32" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="32" id="AtP-2f-wy7"/>
+                                <constraint firstAttribute="width" constant="32" id="jD6-y9-uts"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                            <state key="normal" title="×">
+                                <color key="titleColor" red="0.1764705882" green="0.61568627450000002" blue="0.73725490199999999" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                            </state>
+                            <state key="highlighted">
+                                <color key="titleColor" red="0.60680000000000001" green="0.77380666666666675" blue="0.82000000000000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </state>
+                        </button>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iEM-Xz-y9V">
+                            <rect key="frame" x="268" y="48" width="64" height="64"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="64" id="BPK-fD-g5C"/>
+                                <constraint firstAttribute="height" constant="64" id="UXy-HR-HRw"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="288" translatesAutoresizingMaskIntoConstraints="NO" id="pQz-VN-6MZ">
+                            <rect key="frame" x="275" y="128" width="51" height="24"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                            <color key="textColor" red="0.1764705882" green="0.61568627450000002" blue="0.73725490199999999" alpha="1" colorSpace="calibratedRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="centerX" secondItem="iEM-Xz-y9V" secondAttribute="centerX" id="7Cc-Tb-7ZU"/>
+                        <constraint firstAttribute="centerX" secondItem="pQz-VN-6MZ" secondAttribute="centerX" id="CAd-uj-EDS"/>
+                        <constraint firstItem="kv2-l0-R3n" firstAttribute="top" secondItem="Rj8-Qz-eTI" secondAttribute="top" constant="20" id="CZk-zh-bWd"/>
+                        <constraint firstItem="kv2-l0-R3n" firstAttribute="leading" secondItem="Rj8-Qz-eTI" secondAttribute="leading" constant="16" id="EdM-ey-nzQ"/>
+                        <constraint firstItem="iEM-Xz-y9V" firstAttribute="top" secondItem="Rj8-Qz-eTI" secondAttribute="top" constant="48" id="H0N-lH-WwU"/>
+                        <constraint firstItem="pQz-VN-6MZ" firstAttribute="top" secondItem="iEM-Xz-y9V" secondAttribute="bottom" constant="16" id="fNq-AH-0jT"/>
+                        <constraint firstAttribute="bottom" secondItem="pQz-VN-6MZ" secondAttribute="bottom" constant="20" id="wgG-eP-wjM"/>
+                    </constraints>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2Rb-wX-yF0">
+                    <rect key="frame" x="277" y="554" width="46" height="30"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                    <state key="normal" title="Button">
+                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <state key="highlighted">
+                        <color key="titleColor" red="0.60680000000000001" green="0.77380666666666675" blue="0.82000000000000006" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                </button>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="288" translatesAutoresizingMaskIntoConstraints="NO" id="SOf-O5-Nx9">
+                    <rect key="frame" x="279" y="192" width="42" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="0.1764705882" green="0.61568627450000002" blue="0.73725490199999999" alpha="1" colorSpace="calibratedRGB"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="SOf-O5-Nx9" secondAttribute="trailing" constant="8" id="7UB-Zb-sya"/>
+                <constraint firstAttribute="centerX" secondItem="2Rb-wX-yF0" secondAttribute="centerX" id="GKR-5i-Cnx"/>
+                <constraint firstItem="Rj8-Qz-eTI" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="O0D-dy-yUn"/>
+                <constraint firstAttribute="centerX" secondItem="SOf-O5-Nx9" secondAttribute="centerX" id="QPq-rp-wjg"/>
+                <constraint firstItem="SOf-O5-Nx9" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="QV2-Vb-4IF"/>
+                <constraint firstItem="SOf-O5-Nx9" firstAttribute="top" secondItem="Rj8-Qz-eTI" secondAttribute="bottom" constant="8" id="QXB-w1-Mt0"/>
+                <constraint firstAttribute="bottom" secondItem="2Rb-wX-yF0" secondAttribute="bottom" constant="16" id="YaG-Bz-CtM"/>
+                <constraint firstItem="Rj8-Qz-eTI" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="dE4-mj-yCm"/>
+                <constraint firstItem="SOf-O5-Nx9" firstAttribute="top" secondItem="Rj8-Qz-eTI" secondAttribute="bottom" constant="20" id="fr8-A6-VFA"/>
+                <constraint firstAttribute="trailing" secondItem="Rj8-Qz-eTI" secondAttribute="trailing" id="gGX-gN-Ewn"/>
+            </constraints>
+            <variation key="default">
+                <mask key="constraints">
+                    <exclude reference="7UB-Zb-sya"/>
+                    <exclude reference="QV2-Vb-4IF"/>
+                    <exclude reference="QXB-w1-Mt0"/>
+                </mask>
+            </variation>
+            <connections>
+                <outlet property="cancelInviteButton" destination="kv2-l0-R3n" id="35K-xK-yDL"/>
+                <outlet property="cancelTopConstraint" destination="CZk-zh-bWd" id="K0f-by-u6g"/>
+                <outlet property="confirmInviteButton" destination="2Rb-wX-yF0" id="bvj-Sb-TqA"/>
+                <outlet property="userImageTopConstraint" destination="H0N-lH-WwU" id="tQK-HQ-Mez"/>
+                <outlet property="userImageView" destination="iEM-Xz-y9V" id="Lc6-1E-dXA"/>
+                <outlet property="welcomeBodyLabel" destination="SOf-O5-Nx9" id="fNi-nM-Qt2"/>
+                <outlet property="welcomeTitleLabel" destination="pQz-VN-6MZ" id="6iS-Ie-SyM"/>
+            </connections>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
with the way we package up our invite bundle, the OS creates compiled xibs--nibs--but when an iPad opens this app, the os cannot locate the compiled nibs specific to the ipad (despite these .xibs being universal).

by creating the same xibs with ~iphone appended to the end, we are able to bypass this, as the os correctly locates and retrieves the same .xibs for iPhone and iPad views.

TO TEST: copy master, deploy to iPad. Crash. copy this branch. rebuild. deploy to iPad. voila.

@derrickstaten @aaustin 