### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ func application(application: UIApplication, openURL url: NSURL, sourceApplicati
 The deep link handler is called every single time the app is opened, returning deep link data if the user tapped on a link that led to this app open.
 
 This same code also triggers the recording of an event with Branch. If this is the first time a user has opened the app, an "install" event is registered. Every subsequent time the user opens the app, it will trigger an "open" event.
-This project is built with, and currently relies on, Cocoapods. To add this project to your app, add the following to your Podfile
+This project is built with, and currently relies on, CocoaPods. To add this project to your app, add the following to your Podfile
 
 ## 4. Retrieving Invite Parameters from Session Init
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
