### PR TITLE
Mark InvitingUserId required.

### DIFF
--- a/Classes/Invite/BranchInviteControllerDelegate.h
+++ b/Classes/Invite/BranchInviteControllerDelegate.h
@@ -52,9 +52,10 @@
 // Shown in the Welcome screen when an invited user logs in.
 - (NSString *)invitingUserFullname;
 
-@optional
 // Inviting user identifier. Will be bundled w/ invite url.
 - (NSString *)invitingUserId;
+
+@optional
 
 // Additional items to add to the Branch URL that will be
 // created. This can include any custom NSJSONSerializable


### PR DESCRIPTION
InvitingUserId is [required](https://github.com/BranchMetrics/Branch-iOS-Invite-SDK/blob/e308154851ea2250167f5f5101206f5e61db9b9f/Classes/Invite/BranchInviteViewController.m#L293), and should be marked as such in the delegate.